### PR TITLE
fix: improve cloud filtering consistency in replays store

### DIFF
--- a/src/ui/src/pages/desktop/stores/ReplaysStore.ts
+++ b/src/ui/src/pages/desktop/stores/ReplaysStore.ts
@@ -21,7 +21,7 @@ export const useReplaysStore = defineStore('replaysStore', () => {
   const lastOpenReplay = Vue.ref<IHeroSessionsListResult>(null);
 
   async function onClient(cloud: ICloudConnection, client: Client<'desktop'>): Promise<void> {
-    if (cloud.type !== 'local') return;
+    if (cloud.type !== "local" && !cloud.adminIdentity) return;
     client.removeEventListeners('Sessions.listUpdated');
     client.on('Sessions.listUpdated', x => onSessionList(cloud, client.address, x));
     const list = await client.send('Sessions.list');


### PR DESCRIPTION
This ensures that the cloud filtering in the replays store is consistent
with the replays cloud selector, tracking only local clouds and clouds
that with a `adminIdentity`.

The filter used in the replays cloud selector, for reference:

https://github.com/ulixee/desktop/blob/2fc6ba52fed11d6adc4c9edeeae76c9744bc38c6/src/ui/src/pages/desktop/views/Replays.vue#L220-L225